### PR TITLE
Bugfix: undefined method to_language_code_select_tag in Rails 4.1

### DIFF
--- a/lib/i18n_language_select.rb
+++ b/lib/i18n_language_select.rb
@@ -1,7 +1,7 @@
 require "i18n_language_select/version"
+require "i18n_language_select/form_builder"
 require "i18n_language_select/form_helpers"
 require "i18n_language_select/instance_tag"
-require "i18n_language_select/form_builder"
 require 'i18n_language_select/railtie' if defined?(Rails)
 
 module I18nLanguageSelect
@@ -39,7 +39,7 @@ end
 
 ActionView::Base.send(:include, I18nLanguageSelect::FormHelpers)
 if Rails::VERSION::MAJOR >= 4
-  ActionView::Helpers::ActiveModelInstanceTag.send(:include, I18nLanguageSelect::InstanceTag)
+  ActionView::Helpers::Tags::Select.send(:include, I18nLanguageSelect::InstanceTag)
 else
   ActionView::Helpers::InstanceTag.send(:include, I18nLanguageSelect::InstanceTag)
 end

--- a/lib/i18n_language_select/form_helpers.rb
+++ b/lib/i18n_language_select/form_helpers.rb
@@ -2,7 +2,8 @@ module I18nLanguageSelect
   module FormHelpers
     def language_code_select(object_name, method, priority_languages = nil, options = {}, html_options = {})
       if Rails::VERSION::MAJOR >= 4
-        instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
+        # instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
+        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
       else
         instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options, options)
       end

--- a/lib/i18n_language_select/form_helpers.rb
+++ b/lib/i18n_language_select/form_helpers.rb
@@ -2,7 +2,7 @@ module I18nLanguageSelect
   module FormHelpers
     def language_code_select(object_name, method, priority_languages = nil, options = {}, html_options = {})
       if Rails::VERSION::MAJOR >= 4
-        instance_tag = ActionView::Helpers::ActiveModelInstanceTag.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
+        instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
       else
         instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options, options)
       end

--- a/lib/i18n_language_select/form_helpers.rb
+++ b/lib/i18n_language_select/form_helpers.rb
@@ -2,9 +2,11 @@ module I18nLanguageSelect
   module FormHelpers
     def language_code_select(object_name, method, priority_languages = nil, options = {}, html_options = {})
       if Rails::VERSION::MAJOR >= 4
-        instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
+        instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options)
+        instance_tag.to_language_code_select_tag(priority_languages, html_options)
       else
-        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options, options)
+        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object))
+        instance.to_language_code_select_tag(priority_languages, html_options, options)
       end
     end
   end

--- a/lib/i18n_language_select/form_helpers.rb
+++ b/lib/i18n_language_select/form_helpers.rb
@@ -2,9 +2,9 @@ module I18nLanguageSelect
   module FormHelpers
     def language_code_select(object_name, method, priority_languages = nil, options = {}, html_options = {})
       if Rails::VERSION::MAJOR >= 4
-        ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options)
+        instance_tag = ActionView::Helpers::ActiveModelInstanceTag.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
       else
-        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self).to_language_code_select_tag(priority_languages, html_options, options)
+        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options, options)
       end
     end
   end

--- a/lib/i18n_language_select/form_helpers.rb
+++ b/lib/i18n_language_select/form_helpers.rb
@@ -2,11 +2,9 @@ module I18nLanguageSelect
   module FormHelpers
     def language_code_select(object_name, method, priority_languages = nil, options = {}, html_options = {})
       if Rails::VERSION::MAJOR >= 4
-        instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options)
-        instance_tag.to_language_code_select_tag(priority_languages, html_options)
+        instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
       else
-        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object))
-        instance_tag.to_language_code_select_tag(priority_languages, html_options, options)
+        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options, options)
       end
     end
   end

--- a/lib/i18n_language_select/form_helpers.rb
+++ b/lib/i18n_language_select/form_helpers.rb
@@ -2,8 +2,7 @@ module I18nLanguageSelect
   module FormHelpers
     def language_code_select(object_name, method, priority_languages = nil, options = {}, html_options = {})
       if Rails::VERSION::MAJOR >= 4
-        # instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
-        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
+        instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
       else
         instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options, options)
       end

--- a/lib/i18n_language_select/form_helpers.rb
+++ b/lib/i18n_language_select/form_helpers.rb
@@ -2,9 +2,9 @@ module I18nLanguageSelect
   module FormHelpers
     def language_code_select(object_name, method, priority_languages = nil, options = {}, html_options = {})
       if Rails::VERSION::MAJOR >= 4
-        instance_tag = ActionView::Helpers::Tags::Select.new(object_name, method, self, [], options, html_options).to_language_code_select_tag(priority_languages, html_options)
+        ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options)
       else
-        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object)).to_language_code_select_tag(priority_languages, html_options, options)
+        instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self).to_language_code_select_tag(priority_languages, html_options, options)
       end
     end
   end

--- a/lib/i18n_language_select/form_helpers.rb
+++ b/lib/i18n_language_select/form_helpers.rb
@@ -6,7 +6,7 @@ module I18nLanguageSelect
         instance_tag.to_language_code_select_tag(priority_languages, html_options)
       else
         instance_tag = ActionView::Helpers::InstanceTag.new(object_name, method, self, options.delete(:object))
-        instance.to_language_code_select_tag(priority_languages, html_options, options)
+        instance_tag.to_language_code_select_tag(priority_languages, html_options, options)
       end
     end
   end


### PR DESCRIPTION
i got an error: undefined method to_language_code_select_tag in Rails 4.1
i solved this error when i changed `ActionView::Helpers::ActiveModelInstanceTag.send(:include, I18nLanguageSelect::InstanceTag)` to `ActionView::Helpers::Tags::Select.send(:include, I18nLanguageSelect::InstanceTag)` in lib/i18n_language_select.rb and now it works for me.